### PR TITLE
[#15] API 문서의 호스트 주소 변경

### DIFF
--- a/src/test/java/dev/idion/bladitodo/controller/MockAPIControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/controller/MockAPIControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@AutoConfigureRestDocs(uriHost = "52.78.241.12/api", uriPort = 80)
+@AutoConfigureRestDocs(uriHost = "54.180.198.188/api", uriPort = 80)
 @WebMvcTest(controllers = {MockAPIController.class})
 @DisplayName("Mock API 테스트")
 class MockAPIControllerTest {


### PR DESCRIPTION
Fixes #15

## 설명

API문서에 이전 IP가 표기되어 있던 것을 수정했습니다.

## 작업 유형

- [x] 신규 기능 추가 & 변경
- [ ] 버그 수정

## 체크리스트

- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

