### PR TITLE
[#28]Card가 유저의 프로필 이미지 정보도 반환해줄 수 있도록 수정

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -1,6 +1,6 @@
 = BlaDi Todo API Docs
 Dion[idion@idion.dev]
-1.0.1, 2020/12/02
+1.0.2, 2020/12/03
 :doctype: book
 :sectlinks:
 :docinfo: shared-head
@@ -11,6 +11,8 @@ Dion[idion@idion.dev]
 :sectnums:
 
 == 변경사항
+
+(2020/12/03 17:44) 카드에 유저 프로필 이미지 정보가 추가되었습니다.
 
 == v1 API
 

--- a/src/docs/asciidoc/mock-api-docs.adoc
+++ b/src/docs/asciidoc/mock-api-docs.adoc
@@ -1,6 +1,6 @@
-= BlaDi Todo API Docs
+= BlaDi Todo Mock API Docs
 Dion[idion@idion.dev]
-1.0.1, 2020/11/30
+1.0.2, 2020/12/03
 :doctype: book
 :sectlinks:
 :docinfo: shared-head
@@ -13,6 +13,8 @@ Dion[idion@idion.dev]
 == 변경사항
 
 (2020/11/30 18:02) 카드에서 user DB id 정보를 제거했습니다.
+
+(2020/12/03 17:44) 카드에 유저 프로필 이미지 정보가 추가되었습니다.
 
 == Mock API
 

--- a/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
@@ -17,17 +17,19 @@ public class CardDTO {
   private String contents;
   private boolean isArchived;
   private String userId;
+  private String profileImageUrl;
   private Long listId;
   private LocalDateTime archivedDatetime;
 
   @Builder(setterPrefix = "with")
   private CardDTO(Long id, String title, String contents, boolean isArchived, String userId,
-      Long listId, LocalDateTime archivedDatetime) {
+      String profileImageUrl, Long listId, LocalDateTime archivedDatetime) {
     this.id = id;
     this.title = title;
     this.contents = contents;
     this.isArchived = isArchived;
     this.userId = userId;
+    this.profileImageUrl = profileImageUrl;
     this.listId = listId;
     this.archivedDatetime = archivedDatetime;
   }
@@ -39,6 +41,7 @@ public class CardDTO {
         .withContents(card.getContents())
         .withIsArchived(card.isArchived())
         .withUserId(card.getUser().getUserId())
+        .withProfileImageUrl(card.getUser().getProfileImageUrl())
         .withListId(card.getList().getId())
         .withArchivedDatetime(card.getArchivedDatetime())
         .build();

--- a/src/main/java/dev/idion/bladitodo/web/mockapi/MockAPIController.java
+++ b/src/main/java/dev/idion/bladitodo/web/mockapi/MockAPIController.java
@@ -63,6 +63,8 @@ public class MockAPIController {
     UserDTO user = UserDTO.builder()
         .withId(1L)
         .withUserId("ksundong")
+        .withProfileImageUrl(
+            "https://avatars0.githubusercontent.com/u/38597469?s=88&u=4dec19ec378bfb64c9b4a00c4d63e7805dac9c6c&v=4")
         .build();
 
     BoardDTO manualBoard = BoardDTO.builder()
@@ -84,6 +86,7 @@ public class MockAPIController {
         .withContents("mock API라도 문서는 필요하잖아요!")
         .withListId(list1.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
     CardDTO card2 = CardDTO.builder()
         .withId(2L)
@@ -91,6 +94,7 @@ public class MockAPIController {
         .withContents("mock API 잘 만들기")
         .withListId(list2.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
     CardDTO card3 = CardDTO.builder()
         .withId(3L)
@@ -98,6 +102,7 @@ public class MockAPIController {
         .withContents("환경설정 잘 하기")
         .withListId(list3.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
 
     list1.getCards().add(card1);

--- a/src/test/java/dev/idion/bladitodo/web/MockAPIControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/MockAPIControllerTest.java
@@ -87,6 +87,8 @@ class MockAPIControllerTest {
                     .type(JsonFieldType.STRING),
                 fieldWithPath("lists[].cards[].user_id").description("카드 소유자의 id")
                     .type(JsonFieldType.STRING),
+                fieldWithPath("lists[].cards[].profile_image_url").description("카드 소유자의 프로필 이미지")
+                    .type(JsonFieldType.STRING),
                 fieldWithPath("lists[].cards[].list_id").description("카드가 속한 리스트의 DB id")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("lists[].cards[].archived").description("카드가 아카이브 되었는지 여부")
@@ -143,6 +145,8 @@ class MockAPIControllerTest {
                 fieldWithPath("cards[].title").description("카드의 제목").type(JsonFieldType.STRING),
                 fieldWithPath("cards[].contents").description("카드의 내용").type(JsonFieldType.STRING),
                 fieldWithPath("cards[].user_id").description("카드 소유자의 id")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("cards[].profile_image_url").description("카드 소유자의 프로필 이미지")
                     .type(JsonFieldType.STRING),
                 fieldWithPath("cards[].list_id").description("카드가 속한 리스트의 DB id")
                     .type(JsonFieldType.NUMBER),

--- a/src/test/java/dev/idion/bladitodo/web/v1/board/BoardControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/board/BoardControllerTest.java
@@ -86,6 +86,8 @@ class BoardControllerTest {
                     .type(JsonFieldType.STRING),
                 fieldWithPath("lists[].cards[].user_id").description("카드 소유자의 id")
                     .type(JsonFieldType.STRING),
+                fieldWithPath("lists[].cards[].profile_image_url").description("카드 소유자의 프로필 이미지")
+                    .type(JsonFieldType.STRING),
                 fieldWithPath("lists[].cards[].list_id").description("카드가 속한 리스트의 DB id")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("lists[].cards[].archived").description("카드가 아카이브 되었는지 여부")
@@ -99,6 +101,8 @@ class BoardControllerTest {
     UserDTO user = UserDTO.builder()
         .withId(1L)
         .withUserId("ksundong")
+        .withProfileImageUrl(
+            "https://avatars0.githubusercontent.com/u/38597469?s=88&u=4dec19ec378bfb64c9b4a00c4d63e7805dac9c6c&v=4")
         .build();
 
     BoardDTO manualBoard = BoardDTO.builder()
@@ -120,6 +124,7 @@ class BoardControllerTest {
         .withContents("mock API라도 문서는 필요하잖아요!")
         .withListId(list1.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
     CardDTO card2 = CardDTO.builder()
         .withId(2L)
@@ -127,6 +132,7 @@ class BoardControllerTest {
         .withContents("mock API 잘 만들기")
         .withListId(list2.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
     CardDTO card3 = CardDTO.builder()
         .withId(3L)
@@ -134,6 +140,7 @@ class BoardControllerTest {
         .withContents("환경설정 잘 하기")
         .withListId(list3.getId())
         .withUserId(user.getUserId())
+        .withProfileImageUrl(user.getProfileImageUrl())
         .build();
 
     list1.getCards().add(card1);

--- a/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
@@ -54,6 +54,7 @@ class CardControllerTest {
     String title = "제목";
     String contents = "내용";
     String userId = "ksundong";
+    String profileImageUrl = "https://avatars0.githubusercontent.com/u/38597469?s=88&u=4dec19ec378bfb64c9b4a00c4d63e7805dac9c6c&v=4";
     CardRequest cardRequest = new CardRequest();
     cardRequest.setTitle(title);
     cardRequest.setContents(contents);
@@ -63,6 +64,7 @@ class CardControllerTest {
         .withTitle(title)
         .withContents(contents)
         .withUserId(userId)
+        .withProfileImageUrl(profileImageUrl)
         .withListId(listId)
         .build();
 
@@ -91,6 +93,8 @@ class CardControllerTest {
                 fieldWithPath("title").description("카드의 제목").type(JsonFieldType.STRING),
                 fieldWithPath("contents").description("카드의 내용").type(JsonFieldType.STRING),
                 fieldWithPath("user_id").description("카드를 생성한 user id").type(JsonFieldType.STRING),
+                fieldWithPath("profile_image_url").description("카드 소유자의 프로필 이미지")
+                    .type(JsonFieldType.STRING),
                 fieldWithPath("list_id").description("카드가 속한 List의 DB id")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("archived").description("카드가 보관처리 되었는지 여부")
@@ -109,6 +113,7 @@ class CardControllerTest {
     String title = "수정한 제목";
     String contents = "수정한 내용";
     String userId = "ksundong";
+    String profileImageUrl = "https://avatars0.githubusercontent.com/u/38597469?s=88&u=4dec19ec378bfb64c9b4a00c4d63e7805dac9c6c&v=4";
     CardRequest cardRequest = new CardRequest();
     cardRequest.setTitle(title);
     cardRequest.setContents(contents);
@@ -118,6 +123,7 @@ class CardControllerTest {
         .withTitle(title)
         .withContents(contents)
         .withUserId(userId)
+        .withProfileImageUrl(profileImageUrl)
         .withListId(listId)
         .build();
 
@@ -149,6 +155,8 @@ class CardControllerTest {
                 fieldWithPath("title").description("카드의 수정된 제목").type(JsonFieldType.STRING),
                 fieldWithPath("contents").description("카드의 수정된 내용").type(JsonFieldType.STRING),
                 fieldWithPath("user_id").description("카드를 생성한 user id").type(JsonFieldType.STRING),
+                fieldWithPath("profile_image_url").description("카드 소유자의 프로필 이미지")
+                    .type(JsonFieldType.STRING),
                 fieldWithPath("list_id").description("카드가 속한 List의 DB id")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("archived").description("카드가 보관처리 되었는지 여부")


### PR DESCRIPTION
Fixes #28

## 설명

Card에 유저의 프로필 이미지 url 정보가 담기게 됩니다.
## 작업 유형

- [x] 신규 기능 추가 & 변경
- [ ] 버그 수정

## 체크리스트

- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
