### PR TITLE
[#32]List 관련 API 추가 및 API 문서 수정

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -130,6 +130,38 @@ include::{snippets}/card-controller-test/card_삭제_api_테스트/path-paramete
 
 include::{snippets}/card-controller-test/card_삭제_api_테스트/http-response.adoc[]
 
+=== List
+
+==== POST List: 리스트 생성 API
+
+===== CURL
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/curl-request.adoc[]
+
+===== HTTPie
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/httpie-request.adoc[]
+
+===== HTTP Request
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/http-request.adoc[]
+
+===== HTTP Request Path Parameters
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/path-parameters.adoc[]
+
+===== HTTP Request Fields
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/request-fields.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/http-response.adoc[]
+
+===== HTTP Response Fields
+
+include::{snippets}/list-controller-test/list_생성_api_테스트/response-fields.adoc[]
+
 === Log
 
 ==== GET Log: 로그 조회 API

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -22,7 +22,7 @@ Dion[idion@idion.dev]
 
 === Board
 
-==== GET Board: 보드 조회 API
+==== `GET` Board: 보드 조회 API
 
 ===== CURL
 
@@ -50,7 +50,7 @@ include::{snippets}/board-controller-test/get-board-dto-test/response-fields.ado
 
 === Card
 
-==== POST Card: 카드 생성 API
+==== `POST` Card: 카드 생성 API
 
 ===== CURL
 
@@ -80,7 +80,7 @@ include::{snippets}/card-controller-test/card_생성_api_테스트/http-response
 
 include::{snippets}/card-controller-test/card_생성_api_테스트/response-fields.adoc[]
 
-==== PUT Card: 카드 수정 API
+==== `PUT` Card: 카드 수정 API
 
 ===== CURL
 
@@ -110,7 +110,7 @@ include::{snippets}/card-controller-test/card_수정_api_테스트/http-response
 
 include::{snippets}/card-controller-test/card_수정_api_테스트/response-fields.adoc[]
 
-==== DELETE Card: 카드 보관 API
+==== `DELETE` Card: 카드 보관 API
 
 ===== CURL
 
@@ -134,7 +134,7 @@ include::{snippets}/card-controller-test/card_삭제_api_테스트/http-response
 
 === List
 
-==== POST List: 리스트 생성 API
+==== `POST` List: 리스트 생성 API
 
 ===== CURL
 
@@ -164,7 +164,7 @@ include::{snippets}/list-controller-test/list_생성_api_테스트/http-response
 
 include::{snippets}/list-controller-test/list_생성_api_테스트/response-fields.adoc[]
 
-==== PUT List: 리스트 이름 수정 API
+==== `PUT` List: 리스트 이름 수정 API
 
 ===== CURL
 
@@ -194,7 +194,7 @@ include::{snippets}/list-controller-test/list_이름_수정_api_테스트/http-r
 
 include::{snippets}/list-controller-test/list_이름_수정_api_테스트/response-fields.adoc[]
 
-==== DELETE List: 리스트 보관 API
+==== `DELETE` List: 리스트 보관 API
 
 ===== CURL
 
@@ -218,7 +218,7 @@ include::{snippets}/list-controller-test/list_보관_api_테스트/http-response
 
 === Log
 
-==== GET Log: 로그 조회 API
+==== `GET` Log: 로그 조회 API
 
 ===== CURL
 

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -162,6 +162,36 @@ include::{snippets}/list-controller-test/list_생성_api_테스트/http-response
 
 include::{snippets}/list-controller-test/list_생성_api_테스트/response-fields.adoc[]
 
+==== PUT List: 리스트 수정 API
+
+===== CURL
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/curl-request.adoc[]
+
+===== HTTPie
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/httpie-request.adoc[]
+
+===== HTTP Request
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/http-request.adoc[]
+
+===== HTTP Request Path Parameters
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/path-parameters.adoc[]
+
+===== HTTP Request Fields
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/request-fields.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/http-response.adoc[]
+
+===== HTTP Response Fields
+
+include::{snippets}/list-controller-test/list_이름_수정_api_테스트/response-fields.adoc[]
+
 === Log
 
 ==== GET Log: 로그 조회 API

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -1,6 +1,6 @@
 = BlaDi Todo API Docs
 Dion[idion@idion.dev]
-1.0.3, 2020/12/03
+1.0.4, 2020/12/05
 :doctype: book
 :sectlinks:
 :docinfo: shared-head
@@ -15,6 +15,8 @@ Dion[idion@idion.dev]
 (2020/12/03 17:44) 카드에 유저 프로필 이미지 정보가 추가되었습니다.
 
 (2020/12/03 22:14) 로그 API가 추가되었습니다.
+
+(2020/12/05 12:22) 리스트 관련 API가 추가되었습니다.
 
 == v1 API
 
@@ -162,7 +164,7 @@ include::{snippets}/list-controller-test/list_생성_api_테스트/http-response
 
 include::{snippets}/list-controller-test/list_생성_api_테스트/response-fields.adoc[]
 
-==== PUT List: 리스트 수정 API
+==== PUT List: 리스트 이름 수정 API
 
 ===== CURL
 
@@ -191,6 +193,28 @@ include::{snippets}/list-controller-test/list_이름_수정_api_테스트/http-r
 ===== HTTP Response Fields
 
 include::{snippets}/list-controller-test/list_이름_수정_api_테스트/response-fields.adoc[]
+
+==== DELETE List: 리스트 보관 API
+
+===== CURL
+
+include::{snippets}/list-controller-test/list_보관_api_테스트/curl-request.adoc[]
+
+===== HTTPie
+
+include::{snippets}/list-controller-test/list_보관_api_테스트/httpie-request.adoc[]
+
+===== HTTP Request
+
+include::{snippets}/list-controller-test/list_보관_api_테스트/http-request.adoc[]
+
+===== HTTP Request Path Parameters
+
+include::{snippets}/list-controller-test/list_보관_api_테스트/path-parameters.adoc[]
+
+===== HTTP Response
+
+include::{snippets}/list-controller-test/list_보관_api_테스트/http-response.adoc[]
 
 === Log
 

--- a/src/main/java/dev/idion/bladitodo/common/error/ErrorResponse.java
+++ b/src/main/java/dev/idion/bladitodo/common/error/ErrorResponse.java
@@ -43,9 +43,9 @@ public class ErrorResponse {
   @Getter
   public static class FieldError {
 
-    private String field;
-    private String value;
-    private String reason;
+    private final String field;
+    private final String value;
+    private final String reason;
 
     private FieldError(final String field, final Object value, final String reason) {
       this.field = field;

--- a/src/main/java/dev/idion/bladitodo/domain/list/List.java
+++ b/src/main/java/dev/idion/bladitodo/domain/list/List.java
@@ -19,10 +19,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.Where;
 
 @Getter
 @ToString(callSuper = true, of = {"id", "name", "isArchived", "board", "archivedDatetime"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "is_archived <> true")
 @Entity
 public class List extends BaseEntity {
 

--- a/src/main/java/dev/idion/bladitodo/domain/list/List.java
+++ b/src/main/java/dev/idion/bladitodo/domain/list/List.java
@@ -3,6 +3,7 @@ package dev.idion.bladitodo.domain.list;
 import dev.idion.bladitodo.domain.base.BaseEntity;
 import dev.idion.bladitodo.domain.board.Board;
 import dev.idion.bladitodo.domain.card.Card;
+import dev.idion.bladitodo.web.v1.list.request.ListRequest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import javax.persistence.Entity;
@@ -61,5 +62,9 @@ public class List extends BaseEntity {
     if (this.board != null && !this.board.getLists().contains(this)) {
       this.board.getLists().add(this);
     }
+  }
+
+  public void rename(ListRequest request) {
+    this.name = request.getName();
   }
 }

--- a/src/main/java/dev/idion/bladitodo/domain/log/LogRepository.java
+++ b/src/main/java/dev/idion/bladitodo/domain/log/LogRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LogRepository extends JpaRepository<Log, Long>, LogRepositoryCustom {
 
-  List<Log> findLogsByBoardIdOrderByIdDesc(Long BoardId);
+  List<Log> findLogsByBoardIdOrderByIdDesc(Long boardId);
 }

--- a/src/main/java/dev/idion/bladitodo/service/card/CardService.java
+++ b/src/main/java/dev/idion/bladitodo/service/card/CardService.java
@@ -64,7 +64,6 @@ public class CardService {
     String beforeContents = card.getContents();
     card.updateTitleAndContents(request);
 
-    cardRepository.save(card);
     log.debug("변경된 card 정보: {}", card);
 
     Log cardUpdateLog = Log.builder()
@@ -91,7 +90,6 @@ public class CardService {
       String beforeContents = card.getContents();
       log.debug("보관할 카드 정보: {}", card);
       card.archiveCard();
-      cardRepository.save(card);
 
       Log cardArchiveLog = Log.builder()
           .withType(LogType.CARD_ARCHIVE)

--- a/src/main/java/dev/idion/bladitodo/service/card/CardService.java
+++ b/src/main/java/dev/idion/bladitodo/service/card/CardService.java
@@ -84,22 +84,19 @@ public class CardService {
   public void archiveCard(Long listId, Long cardId) {
     listRepository.findById(listId).orElseThrow(ListNotFoundException::new);
 
-    try {
-      Card card = cardRepository.findById(cardId).orElseThrow(CardNotFoundException::new);
-      String beforeTitle = card.getTitle();
-      String beforeContents = card.getContents();
-      log.debug("보관할 카드 정보: {}", card);
-      card.archiveCard();
+    Card card = cardRepository.findById(cardId).orElseThrow(CardNotFoundException::new);
+    String beforeTitle = card.getTitle();
+    String beforeContents = card.getContents();
+    log.debug("보관할 카드 정보: {}", card);
+    card.archiveCard();
 
-      Log cardArchiveLog = Log.builder()
-          .withType(LogType.CARD_ARCHIVE)
-          .withFromListId(listId)
-          .withBeforeTitle(beforeTitle)
-          .withBeforeContents(beforeContents)
-          .withBoard(card.getList().getBoard())
-          .build();
-      logRepository.save(cardArchiveLog);
-    } catch (RuntimeException ignored) {
-    }
+    Log cardArchiveLog = Log.builder()
+        .withType(LogType.CARD_ARCHIVE)
+        .withFromListId(listId)
+        .withBeforeTitle(beforeTitle)
+        .withBeforeContents(beforeContents)
+        .withBoard(card.getList().getBoard())
+        .build();
+    logRepository.save(cardArchiveLog);
   }
 }

--- a/src/main/java/dev/idion/bladitodo/service/list/ListService.java
+++ b/src/main/java/dev/idion/bladitodo/service/list/ListService.java
@@ -1,6 +1,7 @@
 package dev.idion.bladitodo.service.list;
 
 import dev.idion.bladitodo.common.error.exception.domain.BoardNotFoundException;
+import dev.idion.bladitodo.common.error.exception.domain.ListNotFoundException;
 import dev.idion.bladitodo.domain.board.Board;
 import dev.idion.bladitodo.domain.board.BoardRepository;
 import dev.idion.bladitodo.domain.list.List;
@@ -41,6 +42,25 @@ public class ListService {
         .withBoard(list.getBoard())
         .build();
     logRepository.save(cardAddLog);
+
+    return ListDTO.from(list);
+  }
+
+  public ListDTO updateListNameOf(Long boardId, Long listId, ListRequest request) {
+    boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
+
+    log.debug("리스트 요청 객체: {}", request);
+    List list = listRepository.findById(listId).orElseThrow(ListNotFoundException::new);
+    list.rename(request);
+    log.debug("변경된 list 정보: {}", list);
+
+    Log listNameUpdateLog = Log.builder()
+        .withType(LogType.LIST_RENAME)
+        .withFromListId(list.getId())
+        .withToListId(list.getId())
+        .withBoard(list.getBoard())
+        .build();
+    logRepository.save(listNameUpdateLog);
 
     return ListDTO.from(list);
   }

--- a/src/main/java/dev/idion/bladitodo/service/list/ListService.java
+++ b/src/main/java/dev/idion/bladitodo/service/list/ListService.java
@@ -64,4 +64,19 @@ public class ListService {
 
     return ListDTO.from(list);
   }
+
+  public void archiveList(Long boardId, Long listId) {
+    boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
+
+    List list = listRepository.findById(listId).orElseThrow(ListNotFoundException::new);
+    log.debug("보관할 리스트 정보: {}", list);
+    list.archiveList();
+
+    Log listArchiveLog = Log.builder()
+        .withType(LogType.LIST_ARCHIVE)
+        .withFromListId(list.getId())
+        .withBoard(list.getBoard())
+        .build();
+    logRepository.save(listArchiveLog);
+  }
 }

--- a/src/main/java/dev/idion/bladitodo/service/list/ListService.java
+++ b/src/main/java/dev/idion/bladitodo/service/list/ListService.java
@@ -1,0 +1,47 @@
+package dev.idion.bladitodo.service.list;
+
+import dev.idion.bladitodo.common.error.exception.domain.BoardNotFoundException;
+import dev.idion.bladitodo.domain.board.Board;
+import dev.idion.bladitodo.domain.board.BoardRepository;
+import dev.idion.bladitodo.domain.list.List;
+import dev.idion.bladitodo.domain.list.ListRepository;
+import dev.idion.bladitodo.domain.log.Log;
+import dev.idion.bladitodo.domain.log.LogRepository;
+import dev.idion.bladitodo.domain.log.LogType;
+import dev.idion.bladitodo.web.dto.ListDTO;
+import dev.idion.bladitodo.web.v1.list.request.ListRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class ListService {
+
+  private final ListRepository listRepository;
+  private final BoardRepository boardRepository;
+  private final LogRepository logRepository;
+
+  public ListDTO createListInto(Long boardId, ListRequest request) {
+    log.debug("리스트 요청 객체: {}", request);
+    List list = request.toEntity();
+    Board board = boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
+
+    list.setBoard(board);
+    list = listRepository.save(list);
+    log.debug("저장된 List 정보: {}", list);
+
+    Log cardAddLog = Log.builder()
+        .withType(LogType.LIST_ADD)
+        .withFromListId(list.getId())
+        .withToListId(list.getId())
+        .withBoard(list.getBoard())
+        .build();
+    logRepository.save(cardAddLog);
+
+    return ListDTO.from(list);
+  }
+}

--- a/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
@@ -23,6 +23,7 @@ public class CardController {
 
   private final CardService cardService;
 
+  @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public CardDTO createCard(@PathVariable Long listId, @RequestBody CardRequest request) {
     CardDTO createdCard = cardService.createCardInto(listId, request);

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
@@ -40,4 +40,10 @@ public class ListController {
 
     return list;
   }
+
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @DeleteMapping("/{listId}")
+  public void archiveListName(@PathVariable Long boardId, @PathVariable Long listId) {
+    listService.archiveList(boardId, listId);
+  }
 }

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
@@ -1,0 +1,29 @@
+package dev.idion.bladitodo.web.v1.list;
+
+import dev.idion.bladitodo.service.list.ListService;
+import dev.idion.bladitodo.web.dto.ListDTO;
+import dev.idion.bladitodo.web.v1.list.request.ListRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/board/{boardId}/list")
+public class ListController {
+
+  private final ListService listService;
+
+  @PostMapping
+  public ListDTO createList(@PathVariable Long boardId, @RequestBody ListRequest listRequest) {
+    ListDTO list = listService.createListInto(boardId, listRequest);
+    log.debug("생성된 list 정보: {}", list);
+
+    return list;
+  }
+}

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
@@ -5,11 +5,14 @@ import dev.idion.bladitodo.web.dto.ListDTO;
 import dev.idion.bladitodo.web.v1.list.request.ListRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -20,6 +23,7 @@ public class ListController {
 
   private final ListService listService;
 
+  @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public ListDTO createList(@PathVariable Long boardId, @RequestBody ListRequest listRequest) {
     ListDTO list = listService.createListInto(boardId, listRequest);

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +24,15 @@ public class ListController {
   public ListDTO createList(@PathVariable Long boardId, @RequestBody ListRequest listRequest) {
     ListDTO list = listService.createListInto(boardId, listRequest);
     log.debug("생성된 list 정보: {}", list);
+
+    return list;
+  }
+
+  @PutMapping("/{listId}")
+  public ListDTO updateListName(@PathVariable Long boardId, @PathVariable Long listId,
+      @RequestBody ListRequest listRequest) {
+    ListDTO list = listService.updateListNameOf(boardId, listId, listRequest);
+    log.debug("변경된 list 정보: {}", list);
 
     return list;
   }

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/request/ListRequest.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/request/ListRequest.java
@@ -1,0 +1,20 @@
+package dev.idion.bladitodo.web.v1.list.request;
+
+import dev.idion.bladitodo.domain.list.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class ListRequest {
+
+  private String name;
+
+  public List toEntity() {
+    return List.builder().withName(this.name).build();
+  }
+}

--- a/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
@@ -78,7 +78,7 @@ class CardControllerTest {
         .content(asJsonString(cardRequest));
     mockMvc.perform(requestBuilder)
         .andDo(print())
-        .andExpect(status().isOk())
+        .andExpect(status().isCreated())
         .andDo(document("{class-name}/{method-name}",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),

--- a/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/card/CardControllerTest.java
@@ -55,6 +55,7 @@ class CardControllerTest {
     String contents = "내용";
     String userId = "ksundong";
     String profileImageUrl = "https://avatars0.githubusercontent.com/u/38597469?s=88&u=4dec19ec378bfb64c9b4a00c4d63e7805dac9c6c&v=4";
+    // CardRequest
     CardRequest cardRequest = new CardRequest();
     cardRequest.setTitle(title);
     cardRequest.setContents(contents);

--- a/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import dev.idion.bladitodo.service.list.ListService;
 import dev.idion.bladitodo.web.dto.ListDTO;
@@ -69,6 +70,7 @@ class ListControllerTest {
         .content(asJsonString(listRequest));
     mockMvc.perform(requestBuilder)
         .andDo(print())
+        .andExpect(status().isOk())
         .andDo(document("{class-name}/{method-name}",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),

--- a/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -28,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -48,18 +50,12 @@ class ListControllerTest {
   @Test
   void List_생성_API_테스트() throws Exception {
     //given
+    long listId = 1L;
     long boardId = 1L;
     String name = "리스트 이름";
-    // ListRequest
-    ListRequest listRequest = new ListRequest();
-    listRequest.setName(name);
-    // ListDTO
-    ListDTO listDTO = ListDTO.builder()
-        .withId(1L)
-        .withName(name)
-        .withBoardId(boardId)
-        .withCards(new ArrayList<>())
-        .build();
+
+    ListRequest listRequest = makeListRequest(name);
+    ListDTO listDTO = makeListDTO(boardId, listId, name);
 
     //when
     when(listService.createListInto(eq(boardId), any(ListRequest.class))).thenReturn(listDTO);
@@ -78,19 +74,84 @@ class ListControllerTest {
                 parameterWithName("board_id").description("리스트를 추가할 board의 DB id")
             ),
             requestFields(
-                fieldWithPath("name").description("리스트의 name").type(JsonFieldType.STRING)
+                getListRequestFieldDescriptors("리스트의 name")
             ),
             responseFields(
-                fieldWithPath("id").description("리스트의 DB id").type(JsonFieldType.NUMBER),
-                fieldWithPath("name").description("리스트의 name").type(JsonFieldType.STRING),
-                fieldWithPath("board_id").description("리스트가 속한 보드의 DB id")
-                    .type(JsonFieldType.NUMBER),
-                fieldWithPath("archived").description("리스트가 보관처리 되었는지 여부")
-                    .type(JsonFieldType.BOOLEAN),
-                fieldWithPath("archived_datetime").description("리스트 보관처리 일자").optional()
-                    .type(JsonFieldType.STRING),
-                fieldWithPath("cards").description("리스트의 카드목록(비어있음)").type(JsonFieldType.ARRAY)
+                getListDtoFieldDescriptors()
             )
         ));
   }
+
+  @Test
+  void List_이름_수정_API_테스트() throws Exception {
+    //given
+    long listId = 1L;
+    long boardId = 1L;
+    String name = "리스트 이름 수정";
+
+    ListRequest listRequest = makeListRequest(name);
+    ListDTO listDTO = makeListDTO(boardId, listId, name);
+
+    //when
+    when(listService.updateListNameOf(eq(boardId), eq(listId), any(ListRequest.class)))
+        .thenReturn(listDTO);
+
+    //then
+    MockHttpServletRequestBuilder requestBuilder =
+        put(PRE_URI + "/board/{board_id}/list/{list_id}", boardId, listId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(asJsonString(listRequest));
+    mockMvc.perform(requestBuilder)
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("board_id").description("리스트가 속한 board의 DB id"),
+                parameterWithName("list_id").description("수정할 list의 DB id")
+            ),
+            requestFields(
+                getListRequestFieldDescriptors("수정할 리스트의 name")
+            ),
+            responseFields(
+                getListDtoFieldDescriptors()
+            )
+        ));
+  }
+
+  private ListRequest makeListRequest(String name) {
+    ListRequest listRequest = new ListRequest();
+    listRequest.setName(name);
+    return listRequest;
+  }
+
+  private ListDTO makeListDTO(Long boardId, Long listId, String name) {
+    return ListDTO.builder()
+        .withId(listId)
+        .withName(name)
+        .withBoardId(boardId)
+        .withCards(new ArrayList<>())
+        .build();
+  }
+
+  private FieldDescriptor[] getListRequestFieldDescriptors(String name) {
+    return new FieldDescriptor[]{
+        fieldWithPath("name").description(name).type(JsonFieldType.STRING)
+    };
+  }
+
+  private FieldDescriptor[] getListDtoFieldDescriptors() {
+    return new FieldDescriptor[]{
+        fieldWithPath("id").description("리스트의 DB id").type(JsonFieldType.NUMBER),
+        fieldWithPath("name").description("리스트의 name").type(JsonFieldType.STRING),
+        fieldWithPath("board_id").description("리스트가 속한 보드의 DB id")
+            .type(JsonFieldType.NUMBER),
+        fieldWithPath("archived").description("리스트가 보관처리 되었는지 여부")
+            .type(JsonFieldType.BOOLEAN),
+        fieldWithPath("archived_datetime").description("리스트 보관처리 일자").optional()
+            .type(JsonFieldType.STRING),
+        fieldWithPath("cards").description("리스트의 카드목록(비어있음)").type(JsonFieldType.ARRAY)};
+  }
+
 }

--- a/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -116,6 +117,28 @@ class ListControllerTest {
             ),
             responseFields(
                 getListDtoFieldDescriptors()
+            )
+        ));
+  }
+
+  @Test
+  void List_보관_API_테스트() throws Exception {
+    //given
+    long listId = 1L;
+    long boardId = 1L;
+
+    //when
+
+    //then
+    mockMvc.perform(delete(PRE_URI + "/board/{board_id}/list/{list_id}", boardId, listId))
+        .andDo(print())
+        .andExpect(status().isNoContent())
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("board_id").description("리스트가 속한 board의 DB id"),
+                parameterWithName("list_id").description("수정할 list의 DB id")
             )
         ));
   }

--- a/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
@@ -1,0 +1,94 @@
+package dev.idion.bladitodo.web.v1.list;
+
+import static dev.idion.bladitodo.util.TestUtil.asJsonString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import dev.idion.bladitodo.service.list.ListService;
+import dev.idion.bladitodo.web.dto.ListDTO;
+import dev.idion.bladitodo.web.v1.list.request.ListRequest;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@AutoConfigureRestDocs(uriHost = "54.180.198.188/api", uriPort = 80)
+@WebMvcTest(controllers = {ListController.class})
+@DisplayName("v1 List API 테스트")
+class ListControllerTest {
+
+  private static final String PRE_URI = "/v1";
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  ListService listService;
+
+  @Test
+  void List_생성_API_테스트() throws Exception {
+    //given
+    long boardId = 1L;
+    String name = "리스트 이름";
+    // ListRequest
+    ListRequest listRequest = new ListRequest();
+    listRequest.setName(name);
+    // ListDTO
+    ListDTO listDTO = ListDTO.builder()
+        .withId(1L)
+        .withName(name)
+        .withBoardId(boardId)
+        .withCards(new ArrayList<>())
+        .build();
+
+    //when
+    when(listService.createListInto(eq(boardId), any(ListRequest.class))).thenReturn(listDTO);
+
+    //then
+    MockHttpServletRequestBuilder requestBuilder = post(PRE_URI + "/board/{board_id}/list", boardId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(asJsonString(listRequest));
+    mockMvc.perform(requestBuilder)
+        .andDo(print())
+        .andDo(document("{class-name}/{method-name}",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("board_id").description("리스트를 추가할 board의 DB id")
+            ),
+            requestFields(
+                fieldWithPath("name").description("리스트의 name").type(JsonFieldType.STRING)
+            ),
+            responseFields(
+                fieldWithPath("id").description("리스트의 DB id").type(JsonFieldType.NUMBER),
+                fieldWithPath("name").description("리스트의 name").type(JsonFieldType.STRING),
+                fieldWithPath("board_id").description("리스트가 속한 보드의 DB id")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("archived").description("리스트가 보관처리 되었는지 여부")
+                    .type(JsonFieldType.BOOLEAN),
+                fieldWithPath("archived_datetime").description("리스트 보관처리 일자").optional()
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("cards").description("리스트의 카드목록(비어있음)").type(JsonFieldType.ARRAY)
+            )
+        ));
+  }
+}

--- a/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/list/ListControllerTest.java
@@ -66,7 +66,7 @@ class ListControllerTest {
         .content(asJsonString(listRequest));
     mockMvc.perform(requestBuilder)
         .andDo(print())
-        .andExpect(status().isOk())
+        .andExpect(status().isCreated())
         .andDo(document("{class-name}/{method-name}",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),

--- a/src/test/java/dev/idion/bladitodo/web/v1/log/LogControllerTest.java
+++ b/src/test/java/dev/idion/bladitodo/web/v1/log/LogControllerTest.java
@@ -49,16 +49,16 @@ class LogControllerTest {
     long boardId = 1L;
     List<LogDTO> logs = Lists.list(
         LogDTO.builder()
-            .withId(1L)
-            .withType(LogType.LIST_ADD)
-            .withToListId(1L)
-            .build(),
-        LogDTO.builder()
             .withId(2L)
             .withType(LogType.CARD_ADD)
             .withAfterTitle("제목")
             .withAfterContents("내용")
             .withFromListId(1L)
+            .withToListId(1L)
+            .build(),
+        LogDTO.builder()
+            .withId(1L)
+            .withType(LogType.LIST_ADD)
             .withToListId(1L)
             .build()
     );


### PR DESCRIPTION
Fixes #32 

## 설명

List 관련 API를 추가합니다.
API 문서를 업데이트 합니다.
잔버그를 제거했습니다.
RESTful한 API 응답을 위해 생성시 201응답을 주도록 변경합니다.

## 작업 유형

- [x] 신규 기능 추가 & 변경
- [x] 버그 수정

## 체크리스트

- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
