### PR TITLE
[#44] 각 요청 후에 로그도 반환하도록 변경

### DIFF
--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -22,6 +22,8 @@ Dion[idion@idion.dev]
 
 (2020/12/05 18:13) Card 추가, 수정 API 응답이 변경되었습니다.
 
+(2020/12/05 19:03) List 추가, 수정 API 응답이 변경되었습니다.
+
 == v1 API
 
 === Board

--- a/src/docs/asciidoc/api-docs.adoc
+++ b/src/docs/asciidoc/api-docs.adoc
@@ -20,6 +20,8 @@ Dion[idion@idion.dev]
 
 (2020/12/05 17:20) Card 관련 API 주소가 변경되었습니다.
 
+(2020/12/05 18:13) Card 추가, 수정 API 응답이 변경되었습니다.
+
 == v1 API
 
 === Board

--- a/src/main/java/dev/idion/bladitodo/service/card/CardService.java
+++ b/src/main/java/dev/idion/bladitodo/service/card/CardService.java
@@ -15,6 +15,8 @@ import dev.idion.bladitodo.domain.log.LogType;
 import dev.idion.bladitodo.domain.user.User;
 import dev.idion.bladitodo.domain.user.UserRepository;
 import dev.idion.bladitodo.web.dto.CardDTO;
+import dev.idion.bladitodo.web.dto.DTOContainer;
+import dev.idion.bladitodo.web.dto.LogDTO;
 import dev.idion.bladitodo.web.v1.card.request.CardRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +35,7 @@ public class CardService {
   private final BoardRepository boardRepository;
   private final LogRepository logRepository;
 
-  public CardDTO createCardInto(Long boardId, Long listId, CardRequest request) {
+  public DTOContainer createCardInto(Long boardId, Long listId, CardRequest request) {
     boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
 
     log.debug("카드요청 객체: {}", request);
@@ -57,10 +59,10 @@ public class CardService {
         .build();
     logRepository.save(cardAddLog);
 
-    return CardDTO.from(card);
+    return new DTOContainer(CardDTO.from(card), LogDTO.from(cardAddLog));
   }
 
-  public CardDTO updateCard(Long boardId, Long listId, Long cardId, CardRequest request) {
+  public DTOContainer updateCard(Long boardId, Long listId, Long cardId, CardRequest request) {
     boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
     listRepository.findById(listId).orElseThrow(ListNotFoundException::new);
 
@@ -84,7 +86,7 @@ public class CardService {
         .build();
     logRepository.save(cardUpdateLog);
 
-    return CardDTO.from(card);
+    return new DTOContainer(CardDTO.from(card), LogDTO.from(cardUpdateLog));
   }
 
   public void archiveCard(Long boardId, Long listId, Long cardId) {

--- a/src/main/java/dev/idion/bladitodo/service/list/ListService.java
+++ b/src/main/java/dev/idion/bladitodo/service/list/ListService.java
@@ -9,7 +9,9 @@ import dev.idion.bladitodo.domain.list.ListRepository;
 import dev.idion.bladitodo.domain.log.Log;
 import dev.idion.bladitodo.domain.log.LogRepository;
 import dev.idion.bladitodo.domain.log.LogType;
+import dev.idion.bladitodo.web.dto.DTOContainer;
 import dev.idion.bladitodo.web.dto.ListDTO;
+import dev.idion.bladitodo.web.dto.LogDTO;
 import dev.idion.bladitodo.web.v1.list.request.ListRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +28,7 @@ public class ListService {
   private final BoardRepository boardRepository;
   private final LogRepository logRepository;
 
-  public ListDTO createListInto(Long boardId, ListRequest request) {
+  public DTOContainer createListInto(Long boardId, ListRequest request) {
     log.debug("리스트 요청 객체: {}", request);
     List list = request.toEntity();
     Board board = boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
@@ -35,18 +37,17 @@ public class ListService {
     list = listRepository.save(list);
     log.debug("저장된 List 정보: {}", list);
 
-    Log cardAddLog = Log.builder()
+    Log listAddLog = Log.builder()
         .withType(LogType.LIST_ADD)
-        .withFromListId(list.getId())
         .withToListId(list.getId())
         .withBoard(list.getBoard())
         .build();
-    logRepository.save(cardAddLog);
+    logRepository.save(listAddLog);
 
-    return ListDTO.from(list);
+    return new DTOContainer(ListDTO.from(list), LogDTO.from(listAddLog));
   }
 
-  public ListDTO updateListNameOf(Long boardId, Long listId, ListRequest request) {
+  public DTOContainer updateListNameOf(Long boardId, Long listId, ListRequest request) {
     boardRepository.findByBoardId(boardId).orElseThrow(BoardNotFoundException::new);
 
     log.debug("리스트 요청 객체: {}", request);
@@ -62,7 +63,7 @@ public class ListService {
         .build();
     logRepository.save(listNameUpdateLog);
 
-    return ListDTO.from(list);
+    return new DTOContainer(ListDTO.from(list), LogDTO.from(listNameUpdateLog));
   }
 
   public void archiveList(Long boardId, Long listId) {

--- a/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor
-public class CardDTO {
+public class CardDTO implements ContainableDTO {
 
   private Long id;
   private String title;

--- a/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
@@ -48,7 +48,7 @@ public class CardDTO implements ContainableDTO {
   }
 
   @Override
-  public String getType() {
+  public String dtoType() {
     return "card";
   }
 }

--- a/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/CardDTO.java
@@ -46,4 +46,9 @@ public class CardDTO implements ContainableDTO {
         .withArchivedDatetime(card.getArchivedDatetime())
         .build();
   }
+
+  @Override
+  public String getType() {
+    return "card";
+  }
 }

--- a/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
@@ -1,0 +1,6 @@
+package dev.idion.bladitodo.web.dto;
+
+// Log 객체와 함께 전달 될 수 있는 DTO
+public interface ContainableDTO {
+
+}

--- a/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
@@ -3,5 +3,5 @@ package dev.idion.bladitodo.web.dto;
 // Log 객체와 함께 전달 될 수 있는 DTO
 public interface ContainableDTO {
 
-  String getType();
+  String dtoType();
 }

--- a/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ContainableDTO.java
@@ -3,4 +3,5 @@ package dev.idion.bladitodo.web.dto;
 // Log 객체와 함께 전달 될 수 있는 DTO
 public interface ContainableDTO {
 
+  String getType();
 }

--- a/src/main/java/dev/idion/bladitodo/web/dto/DTOContainer.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/DTOContainer.java
@@ -12,7 +12,7 @@ public class DTOContainer {
   private final LogDTO log;
 
   public DTOContainer(ContainableDTO result, LogDTO log) {
-    this.resultType = result.getType();
+    this.resultType = result.dtoType();
     this.result = result;
     this.log = log;
   }

--- a/src/main/java/dev/idion/bladitodo/web/dto/DTOContainer.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/DTOContainer.java
@@ -1,0 +1,19 @@
+package dev.idion.bladitodo.web.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class DTOContainer {
+
+  private final String resultType;
+  private final ContainableDTO result;
+  private final LogDTO log;
+
+  public DTOContainer(ContainableDTO result, LogDTO log) {
+    this.resultType = result.getType();
+    this.result = result;
+    this.log = log;
+  }
+}

--- a/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
@@ -45,4 +45,9 @@ public class ListDTO implements ContainableDTO {
             .collect(Collectors.toList()))
         .build();
   }
+
+  @Override
+  public String getType() {
+    return "list";
+  }
 }

--- a/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
@@ -12,7 +12,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor
-public class ListDTO {
+public class ListDTO implements ContainableDTO {
 
   private Long id;
   private String name;

--- a/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
+++ b/src/main/java/dev/idion/bladitodo/web/dto/ListDTO.java
@@ -47,7 +47,7 @@ public class ListDTO implements ContainableDTO {
   }
 
   @Override
-  public String getType() {
+  public String dtoType() {
     return "list";
   }
 }

--- a/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
@@ -45,7 +45,7 @@ public class CardController {
 
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @DeleteMapping("/{cardId}")
-  public void updateCard(@PathVariable Long boardId, @PathVariable Long listId,
+  public void archiveCard(@PathVariable Long boardId, @PathVariable Long listId,
       @PathVariable Long cardId) {
     log.debug("보관 처리할 카드의 id: {}", cardId);
     cardService.archiveCard(boardId, listId, cardId);

--- a/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/card/CardController.java
@@ -1,7 +1,7 @@
 package dev.idion.bladitodo.web.v1.card;
 
 import dev.idion.bladitodo.service.card.CardService;
-import dev.idion.bladitodo.web.dto.CardDTO;
+import dev.idion.bladitodo.web.dto.DTOContainer;
 import dev.idion.bladitodo.web.v1.card.request.CardRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,22 +25,22 @@ public class CardController {
 
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
-  public CardDTO createCard(@PathVariable Long boardId, @PathVariable Long listId,
+  public DTOContainer createCard(@PathVariable Long boardId, @PathVariable Long listId,
       @RequestBody CardRequest request) {
-    CardDTO createdCard = cardService.createCardInto(boardId, listId, request);
-    log.debug("생성된 카드 정보: {}", createdCard);
+    DTOContainer createdCardContainer = cardService.createCardInto(boardId, listId, request);
+    log.debug("생성된 카드 정보: {}", createdCardContainer);
 
-    return createdCard;
+    return createdCardContainer;
   }
 
   @PutMapping("/{cardId}")
-  public CardDTO updateCard(@PathVariable Long boardId, @PathVariable Long listId,
+  public DTOContainer updateCard(@PathVariable Long boardId, @PathVariable Long listId,
       @PathVariable Long cardId,
       @RequestBody CardRequest request) {
-    CardDTO updatedCard = cardService.updateCard(boardId, listId, cardId, request);
-    log.debug("변경된 카드 정보: {}", updatedCard);
+    DTOContainer updatedCardContainer = cardService.updateCard(boardId, listId, cardId, request);
+    log.debug("변경된 카드 정보: {}", updatedCardContainer);
 
-    return updatedCard;
+    return updatedCardContainer;
   }
 
   @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
+++ b/src/main/java/dev/idion/bladitodo/web/v1/list/ListController.java
@@ -1,7 +1,7 @@
 package dev.idion.bladitodo.web.v1.list;
 
 import dev.idion.bladitodo.service.list.ListService;
-import dev.idion.bladitodo.web.dto.ListDTO;
+import dev.idion.bladitodo.web.dto.DTOContainer;
 import dev.idion.bladitodo.web.v1.list.request.ListRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,20 +25,21 @@ public class ListController {
 
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
-  public ListDTO createList(@PathVariable Long boardId, @RequestBody ListRequest listRequest) {
-    ListDTO list = listService.createListInto(boardId, listRequest);
-    log.debug("생성된 list 정보: {}", list);
+  public DTOContainer createList(@PathVariable Long boardId, @RequestBody ListRequest listRequest) {
+    DTOContainer listCreateContainer = listService.createListInto(boardId, listRequest);
+    log.debug("생성된 list 정보: {}", listCreateContainer);
 
-    return list;
+    return listCreateContainer;
   }
 
   @PutMapping("/{listId}")
-  public ListDTO updateListName(@PathVariable Long boardId, @PathVariable Long listId,
+  public DTOContainer updateListName(@PathVariable Long boardId, @PathVariable Long listId,
       @RequestBody ListRequest listRequest) {
-    ListDTO list = listService.updateListNameOf(boardId, listId, listRequest);
-    log.debug("변경된 list 정보: {}", list);
+    DTOContainer listNameUpdateContainer = listService
+        .updateListNameOf(boardId, listId, listRequest);
+    log.debug("변경된 list 정보: {}", listNameUpdateContainer);
 
-    return list;
+    return listNameUpdateContainer;
   }
 
   @ResponseStatus(HttpStatus.NO_CONTENT)


### PR DESCRIPTION
Fixes #44 

## 설명

로그를 매번 호출하게 하는 것이 아닌, 로그를 그 즉시 바로 반환하도록 하여 불필요한 네트워크를 수행하지 않기 위함입니다.

## 작업 유형

- [x] 신규 기능 추가 & 변경
- [x] 버그 수정

## 체크리스트

- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
