### PR TITLE
[#62] flyway db migration tool 설정 및 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,17 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'com.querydsl:querydsl-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+    implementation 'org.flywaydb:flyway-core'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'com.querydsl:querydsl-jpa'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  flyway: # https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#common-application-properties-data-migration 참고
+    baseline-on-migrate: true # 비어있지 않은 db schema를 migration할 때, baseline을 사용할 것인지 여부
+    baseline-version: 1 # 이 버전 이후로 마이그레이션을 진행한다.
+    baseline-description: 기본 스키마 # baseline 적용시 기존 스키마에 태그를 지정
 
 ---
 
@@ -60,6 +64,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  flyway: # https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#common-application-properties-data-migration 참고
+    baseline-on-migrate: true # 비어있지 않은 db schema를 migration할 때, baseline을 사용할 것인지 여부
+    baseline-version: 1 # 이 버전 이후로 마이그레이션을 진행한다.
+    baseline-description: 기본 스키마 # baseline 적용시 기존 스키마에 태그를 지정
 logging:
   level:
     web: info

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,96 @@
+drop table if exists board;
+
+drop table if exists card;
+
+drop table if exists list;
+
+drop table if exists log;
+
+drop table if exists user;
+
+create table board
+(
+    id               bigint auto_increment primary key,
+    name             varchar(255),
+    created_datetime datetime(6),
+    created_by       bigint,
+    updated_datetime datetime(6),
+    updated_by       bigint
+) engine = InnoDB;
+
+create table card
+(
+    id                bigint auto_increment primary key,
+    title             varchar(255),
+    contents          varchar(500),
+    pos               integer not null,
+    is_archived       bit     not null,
+    archived_datetime datetime(6),
+    list_id           bigint,
+    user_id           bigint,
+    created_datetime  datetime(6),
+    created_by        bigint,
+    updated_datetime  datetime(6),
+    updated_by        bigint
+) engine = InnoDB;
+
+create table list
+(
+    id                bigint auto_increment primary key,
+    name              varchar(255),
+    is_archived       bit not null,
+    archived_datetime datetime(6),
+    board_id          bigint,
+    created_datetime  datetime(6),
+    created_by        bigint,
+    updated_datetime  datetime(6),
+    updated_by        bigint
+) engine = InnoDB;
+
+create table log
+(
+    id               bigint auto_increment primary key,
+    type             varchar(255),
+    before_title     varchar(255),
+    after_title      varchar(255),
+    before_contents  varchar(255),
+    after_contents   varchar(255),
+    from_list_id     bigint,
+    to_list_id       bigint,
+    board_id         bigint,
+    created_datetime datetime(6),
+    created_by       bigint,
+    updated_datetime datetime(6),
+    updated_by       bigint
+) engine = InnoDB;
+
+create table user
+(
+    id                bigint auto_increment primary key,
+    user_id           varchar(255),
+    user_nickname     varchar(255),
+    profile_image_url varchar(255),
+    github_token      varchar(255),
+    created_datetime  datetime(6),
+    updated_datetime  datetime(6)
+) engine = InnoDB;
+
+alter table card
+    add constraint card_ref_list
+        foreign key (list_id)
+            references list (id);
+
+alter table card
+    add constraint card_ref_user
+        foreign key (user_id)
+            references user (id);
+
+alter table list
+    add constraint list_ref_board
+        foreign key (board_id)
+            references board (id);
+
+alter table log
+    add constraint log_ref_board
+        foreign key (board_id)
+            references board (id);


### PR DESCRIPTION
Fixes #62 

## 배경

회사에서 Flyway를 적용할 필요성이 있었고, 이를 시험삼아 사이드 프로젝트에 적용하기 위함입니다.

필요했던 이유는, Flyway가 제공해주는 DB 스키마 이력관리 기능 때문입니다.

하면서 느꼈던 점은 Flyway 전용 계정이 있어야 한다고 생각했습니다.

## 설명

- flyway 의존성을 추가합니다.
- plugin은 굳이 추가하지 않았지만, 운영환경에서는 필요할 수도 있을 것 같습니다.

## 작업 유형

- [x] 신규 기능 추가 & 변경

## 체크리스트

- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
