### PR TITLE
[#74] Board, Log Service slice 테스트 추가

### DIFF
--- a/src/test/java/dev/idion/bladitodo/service/board/BoardServiceTest.java
+++ b/src/test/java/dev/idion/bladitodo/service/board/BoardServiceTest.java
@@ -32,7 +32,7 @@ class BoardServiceTest {
   BoardDTO boardDTO;
 
   long existBoardId = 1L;
-  long notExistBoardId = 999999L;
+  long notExistBoardId = 12345678987654L;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/dev/idion/bladitodo/service/board/BoardServiceTest.java
+++ b/src/test/java/dev/idion/bladitodo/service/board/BoardServiceTest.java
@@ -1,0 +1,66 @@
+package dev.idion.bladitodo.service.board;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import dev.idion.bladitodo.common.error.ErrorCode;
+import dev.idion.bladitodo.common.error.exception.domain.BoardNotFoundException;
+import dev.idion.bladitodo.domain.board.Board;
+import dev.idion.bladitodo.domain.board.BoardRepository;
+import dev.idion.bladitodo.web.dto.BoardDTO;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+  @Mock
+  BoardRepository boardRepository;
+
+  @InjectMocks
+  BoardService boardService;
+
+  Board board;
+  BoardDTO boardDTO;
+
+  long existBoardId = 1L;
+  long notExistBoardId = 999999L;
+
+  @BeforeEach
+  void setUp() {
+    String name = "보드 이름";
+    board = Board.builder()
+        .withName(name)
+        .build();
+    boardDTO = BoardDTO.from(board);
+  }
+
+  @Test
+  @DisplayName("boardId 에 해당하는 Board가 존재하는 경우")
+  void findBoardTest() {
+    given(boardRepository.findByBoardId(eq(existBoardId))).willReturn(Optional.of(board));
+
+    BoardDTO findBoardResult = boardService.findBoard(existBoardId);
+
+    assertThat(findBoardResult).usingRecursiveComparison().isEqualTo(boardDTO);
+  }
+
+  @Test
+  @DisplayName("boardId 에 해당하는 Board가 존재하지 않는 경우")
+  void findBoardFailTest() {
+    given(boardRepository.findByBoardId(eq(notExistBoardId))).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> {
+      boardService.findBoard(notExistBoardId);
+    }).isInstanceOf(BoardNotFoundException.class)
+        .hasMessage(ErrorCode.BOARD_NOT_FOUND.getMessage());
+  }
+}

--- a/src/test/java/dev/idion/bladitodo/service/log/LogServiceTest.java
+++ b/src/test/java/dev/idion/bladitodo/service/log/LogServiceTest.java
@@ -1,0 +1,79 @@
+package dev.idion.bladitodo.service.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import dev.idion.bladitodo.common.error.ErrorCode;
+import dev.idion.bladitodo.common.error.exception.domain.BoardNotFoundException;
+import dev.idion.bladitodo.domain.log.Log;
+import dev.idion.bladitodo.domain.log.LogRepository;
+import dev.idion.bladitodo.domain.log.LogType;
+import dev.idion.bladitodo.web.dto.LogDTO;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LogServiceTest {
+
+  @Mock
+  LogRepository logRepository;
+
+  @InjectMocks
+  LogService logService;
+
+  List<Log> logs;
+  List<LogDTO> logDTOs;
+
+  long existBoardId = 1L;
+  long notExistBoardId = 12345678987654L;
+
+  @BeforeEach
+  void setUp() {
+    String title = "카드 제목";
+    String contents = "카드 내용";
+    long listId = 1L;
+
+    logs = Collections.singletonList(
+        Log.builder()
+            .withType(LogType.CARD_ADD)
+            .withAfterTitle(title)
+            .withAfterContents(contents)
+            .withFromListId(listId)
+            .withToListId(listId)
+            .build());
+
+    logDTOs = logs.stream().map(LogDTO::from).collect(Collectors.toList());
+  }
+
+  @Test
+  @DisplayName("boardId에 해당하는 Board가 존재해서 Log가 존재하는 경우")
+  void findLogsTest() {
+    given(logRepository.findLogsByBoardIdOrderByIdDesc(eq(existBoardId))).willReturn(logs);
+
+    List<LogDTO> findLogsResult = logService.findLogs(existBoardId);
+
+    assertThat(findLogsResult).isNotEmpty().hasSize(logs.size())
+        .usingRecursiveFieldByFieldElementComparator().isEqualTo(logDTOs);
+  }
+
+  @Test
+  @DisplayName("boardId에 해당하는 Board가 존재하지 않는 경우")
+  void findLogsFailTest() {
+    given(logRepository.findLogsByBoardIdOrderByIdDesc(eq(existBoardId)))
+        .willReturn(Collections.emptyList());
+
+    assertThatThrownBy(() -> logService.findLogs(existBoardId))
+        .isInstanceOf(BoardNotFoundException.class)
+        .hasMessage(ErrorCode.BOARD_NOT_FOUND.getMessage());
+  }
+}


### PR DESCRIPTION
Fixes #74

## 설명

BoardService와 LogService의 slice test를 추가합니다.

### 배운 것

Mockito를 활용한 Service Layer Slice 테스트

## 작업 유형

- [x] 신규 기능 추가 & 변경
- [x] 버그 수정

## 체크리스트

- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 이해하기 힘든 부분의 코드에 주석이 작성되었는가?
- [x] 변경사항에 대한 문서를 작성하였는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
